### PR TITLE
fix[bluetooth]: fixing the bluetooth setup, and the test driver

### DIFF
--- a/test/unit_tests/bluetooth_sensor/stage-2-test-low-level/bluetooth.h
+++ b/test/unit_tests/bluetooth_sensor/stage-2-test-low-level/bluetooth.h
@@ -1,5 +1,5 @@
 // Author: Abd El-Rahman Mostafa (Modified by Amir)
-// Implementation of the Bluetooth driver for HC-05/HC-06 using direct AVR register access
+// Bluetooth driver for HC-05/HC-06 using direct AVR register access
 
 #ifndef BLUETOOTH_H
 #define BLUETOOTH_H
@@ -13,7 +13,7 @@ class Bluetooth
 {
 private:
     uint32_t baud_rate;
-    uint32_t ubrr;
+    uint16_t ubrr;
 
 public:
     Bluetooth(uint32_t baud_rate = 9600, uint32_t cpu_clock = 16000000UL)
@@ -21,77 +21,80 @@ public:
         this->baud_rate = baud_rate;
         // NOTE: Calculate UBRR value for the desired baud rate
         // Also notice UART normal prescaler is 16
-        ubrr = cpu_clock / 16 / baud_rate - 1;
+        ubrr = (cpu_clock / 16 / baud_rate) - 1;
     }
 
     void begin()
     {
         // Set baud rate
-        UBRR0H = (unsigned char)(ubrr >> 8);
-        UBRR0L = (unsigned char)ubrr;
+        UBRR0H = (uint8_t)(ubrr >> 8);
+        UBRR0L = (uint8_t)(ubrr);
 
-        // Enable RX an TX
-        UCSR0B |= (1 << RXEN0) | (1 << TXEN0);
+        // Enable receiver and transmitter
+        UCSR0B = (1 << RXEN0) | (1 << TXEN0);
 
         // Set frame format: 8 data bits, 2 stop bits
         UCSR0C = (1 << USBS0) | (3 << UCSZ00);
     }
 
-    // Send a character string
+    // Send a null-terminated character string
     void send(const char *data)
     {
-        while (*data != '\0')
+        while (*data)
         {
-            while (!(UCSR0A & (1 << UDRE0)));
-            UDR0 = *data;
-            data++;
+            sendByte(*data++);
         }
     }
 
-    // Send raw bytes
+    // Send raw byte array
     void sendBytes(const uint8_t *data, size_t length)
     {
         for (size_t i = 0; i < length; i++)
         {
-            // Wait for empty transmit buffer
-            while (!(UCSR0A & (1 << UDRE0)));
-            UDR0 = data[i];
+            sendByte(data[i]);
         }
     }
 
+    // Check if data is available to read
     int available()
     {
         return (UCSR0A & (1 << RXC0));
     }
 
-    // Read a single byte
+    // Read a single byte (blocking)
     int read()
     {
-        while (!available());
+        while (!available())
+            ;
         return UDR0;
     }
 
-    // Read a string until newline
+    // Read until newline and return as String
     String readString()
     {
         String result = "";
         char c;
-
         while (true)
         {
             if (available())
             {
                 c = UDR0;
                 if (c == '\n')
-                {
                     break;
-                }
                 result += c;
             }
         }
-
         return result;
+    }
+
+private:
+    // Helper to send a single byte
+    void sendByte(uint8_t byte)
+    {
+        while (!(UCSR0A & (1 << UDRE0)))
+            ; // Wait for empty transmit buffer
+        UDR0 = byte;
     }
 };
 
-#endif
+#endif // BLUETOOTH_H

--- a/test/unit_tests/bluetooth_sensor/stage-2-test-low-level/stage-2-test-low-level.ino
+++ b/test/unit_tests/bluetooth_sensor/stage-2-test-low-level/stage-2-test-low-level.ino
@@ -1,39 +1,50 @@
 #include "bluetooth.h"
-Bluetooth bt(9600);
+
+Bluetooth bt(9600); // HC-05 default baud rate
+
 void setup()
 {
-    Serial.begin(9600);
+    // Only use Serial for setup diagnostics (disconnect HC-05 TX before upload)
+    // Serial.begin(9600);
+    Serial.println("Setting up Bluetooth...");
+
     bt.begin();
     bt.send("Arduino Ready!\n");
-    Serial.println("Bluetooth initialized. Waiting for commands...");
 }
+
 void loop()
 {
     if (bt.available())
     {
         char command = bt.read();
+
 #ifdef IGNORE_ZERO
         if (command == '0')
             return;
 #endif
-        Serial.print("Received: '");
-        Serial.print(command);
-        Serial.print("' (ASCII: ");
-        Serial.print((int)command);
-        Serial.println(")");
+
+        bt.send("Received: '");
+        bt.send(&command);
+        bt.send("' (ASCII: ");
+
+        char asciiBuf[5];
+        itoa((int)command, asciiBuf, 10);
+        bt.send(asciiBuf);
+        bt.send(")\n");
+
         switch (command)
         {
-        case 'R':
-            Serial.println("Reset pressed");
+        case '1':
+            bt.send("Reset pressed\n");
             break;
-        case 'S':
-            Serial.println("Start pressed");
+        case '2':
+            bt.send("Start pressed\n");
             break;
-        case 'P':
-            Serial.println("Parking pressed");
+        case '3':
+            bt.send("Parking pressed\n");
             break;
         default:
-            Serial.println("Unknown command received");
+            bt.send("Unknown command received\n");
             break;
         }
     }


### PR DESCRIPTION
This pull request states the following fixes:

for `bluetooth.h`:

- For the __USART__ control register, I have fixed bit setting, as if anything else was previously set in UCSR0B, this may work fine. But for cleaner behavior, especially since we are not using interrupts or other UART features, it is better to assign directly `        UCSR0B = (1 << RXEN0) | (1 << TXEN0);
`

- Have fixed the method `send()` to send null-terminated character for separation of concerns as corrupted data was sent for each received character, and for code reuse as well

for `stage-2-test-low-level.ino`:

- Deleted all method calls to the class __Serial__, as we access and configures the UART registers by hand and the __Serial__ itself configures it by default